### PR TITLE
Implement creneaux day view

### DIFF
--- a/public/edit_creneau.php
+++ b/public/edit_creneau.php
@@ -1,0 +1,79 @@
+<?php
+session_start();
+require '../actions/users/securityAction.php';
+require '../src/bootstrap.php';
+require '../src/config.php';
+require '../actions/users/userdefinition.php';
+
+$creneaux = new Calendar\Creneaux($pdo, $timezone);
+
+if (!isset($_GET['id'])) {
+    header('Location: gestion_creneaux.php');
+    exit();
+}
+
+$id = (int)$_GET['id'];
+$creneau = $creneaux->getCreneauById($id);
+if (!$creneau) {
+    echo "Créneau introuvable";
+    exit();
+}
+
+if (isset($_POST['save'])) {
+    if (!empty($_POST['date']) && !empty($_POST['start']) && !empty($_POST['end'])) {
+        // La date provenant du champ input est déjà au format YYYY-MM-DD
+        $start = $_POST['date'].' '.$_POST['start'];
+        $end = $_POST['date'].' '.$_POST['end'];
+        $name = $_POST['name'];
+        $description = $_POST['description'];
+        if ($creneaux->updateCreneau($id, $name, $description, $start, $end)) {
+            $message = "Le créneau a été mis à jour.";
+            $creneau = $creneaux->getCreneauById($id);
+        } else {
+            $error = "Erreur lors de la mise à jour.";
+        }
+    } else {
+        $error = "Veuillez remplir tous les champs.";
+    }
+}
+
+entete('Modifier un créneau', 'Modifier un créneau', '4');
+?>
+<div class="container mt-4">
+    <h1>Modifier un créneau</h1>
+    <?php if(isset($message)): ?>
+        <div class="alert alert-success"><?= $message ?></div>
+    <?php endif; ?>
+    <?php if(isset($error)): ?>
+        <div class="alert alert-danger"><?= $error ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <div class="mb-3">
+            <label class="form-label" for="name">Nom</label>
+            <input type="text" class="form-control" name="name" id="name" value="<?= htmlspecialchars($creneau['name']) ?>" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="description">Description</label>
+            <textarea class="form-control" name="description" id="description"><?= htmlspecialchars($creneau['description']) ?></textarea>
+        </div>
+        <div class="row">
+            <div class="col">
+                <label class="form-label" for="date">Date</label>
+                <input type="date" class="form-control" name="date" id="date" value="<?= $creneau['date'] ?>" required>
+            </div>
+            <div class="col">
+                <label class="form-label" for="start">Début</label>
+                <input type="time" class="form-control" name="start" id="start" value="<?= $creneau['start'] ?>" required>
+            </div>
+            <div class="col">
+                <label class="form-label" for="end">Fin</label>
+                <input type="time" class="form-control" name="end" id="end" value="<?= $creneau['end'] ?>" required>
+            </div>
+        </div>
+        <div class="mt-3">
+            <button type="submit" name="save" class="btn btn-primary">Enregistrer</button>
+            <a href="gestion_creneaux.php" class="btn btn-secondary">Retour</a>
+        </div>
+    </form>
+</div>
+<?php include('../includes/footer.php'); ?>

--- a/src/Calendar/Creneaux.php
+++ b/src/Calendar/Creneaux.php
@@ -356,14 +356,43 @@ class Creneaux {
     
     public function getAllCreneaux(): array {
         $query = $this->pdo->query("
-            SELECT id, id_in_day, cat_creneau, 
-                   DATE_FORMAT(start, '%d-%m-%Y') as date, 
-                   TIME_FORMAT(start, '%H:%i') as start, 
-                   TIME_FORMAT(end, '%H:%i') as end, 
-                   name, description 
+            SELECT id, id_in_day, cat_creneau,
+                   DATE_FORMAT(start, '%d-%m-%Y') as date,
+                   TIME_FORMAT(start, '%H:%i') as start,
+                   TIME_FORMAT(end, '%H:%i') as end,
+                   name, description
             FROM events
         ");
         return $query->fetchAll();
+    }
+
+    /**
+     * Retourne un créneau par son identifiant
+     */
+    public function getCreneauById(int $id): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT id, id_in_day, cat_creneau,
+                    DATE_FORMAT(start, '%Y-%m-%d') as date,
+                    TIME_FORMAT(start, '%H:%i') as start,
+                    TIME_FORMAT(end, '%H:%i') as end,
+                    name, description
+             FROM events WHERE id = :id"
+        );
+        $stmt->execute(['id' => $id]);
+        $creneau = $stmt->fetch();
+        return $creneau ?: null;
+    }
+
+    /**
+     * Met à jour un créneau existant
+     */
+    public function updateCreneau(int $id, string $name, string $description, string $start, string $end): bool
+    {
+        $stmt = $this->pdo->prepare(
+            'UPDATE events SET name = ?, description = ?, start = ?, end = ? WHERE id = ?'
+        );
+        return $stmt->execute([$name, $description, $start, $end, $id]);
     }
 
     public function deleteCreneau(int $id): bool {
@@ -449,6 +478,25 @@ class Creneaux {
             ORDER BY start
         ");
         $stmt->execute(['start_date' => $startDate, 'end_date' => $endDate]);
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Retourne l'ensemble des créneaux pour une date donnée
+     */
+    public function getCreneauxByDate(string $date): array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT id, id_in_day, cat_creneau,
+                    DATE_FORMAT(start, '%d-%m-%Y') as date,
+                    TIME_FORMAT(start, '%H:%i') as start,
+                    TIME_FORMAT(end, '%H:%i') as end,
+                    name, description
+             FROM events
+             WHERE DATE(start) = :date
+             ORDER BY id_in_day, start"
+        );
+        $stmt->execute(['date' => $date]);
         return $stmt->fetchAll();
     }
     


### PR DESCRIPTION
## Summary
- add method to fetch timeslots for a specific date
- reorganize management page around a calendar view
- allow selecting a day to list its timeslots

## Testing
- `php -l public/edit_creneau.php`
- `php -l public/gestion_creneaux.php`
- `php -l src/Calendar/Creneaux.php`


------
https://chatgpt.com/codex/tasks/task_e_6883bf85c7d88327824c794a28df303b