### PR TITLE
Ajout recherche par nom/prénom et édition d'habilitation dans public/list.php

### DIFF
--- a/public/list.php
+++ b/public/list.php
@@ -9,54 +9,108 @@ require '../actions/users/userdefinition.php';
 entete('Inscription créneau','Inscrire un bénévole','4');
  
 if(isset($admin)):
+
+$searchTerm = trim($_GET['search'] ?? '');
+$successMessage = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['uuid_user'], $_POST['habilitation'])) {
+    $uuid = trim((string) $_POST['uuid_user']);
+    $habilitation = (int) $_POST['habilitation'];
+
+    if ($uuid !== '' && in_array($habilitation, [1, 2], true)) {
+        $admin->updateHabilitation($uuid, $habilitation);
+        $successMessage = 'Habilitation mise à jour.';
+    }
+}
+
 $listOfUsers = $admin->getAllUsersAndDate();
+
+if ($searchTerm !== '') {
+    $listOfUsers = array_filter($listOfUsers, static function (array $user) use ($searchTerm): bool {
+        $needle = mb_strtolower($searchTerm);
+        $nom = mb_strtolower((string) ($user['nom'] ?? ''));
+        $prenom = mb_strtolower((string) ($user['prenom'] ?? ''));
+
+        return mb_strpos($nom, $needle) !== false || mb_strpos($prenom, $needle) !== false;
+    });
+}
 
 ?>
 
-<div class="container bg-light rounded mt-4 mb-4">
-    <form method="post">
-        <table class="table table-striped">
-            <thead>
-              <tr>
-                <th scope="col">Nom</th>
-                <th scope="col">Prénom</th>
-                <th scope="col">Pseudo</th>
-                <th scope="col">Habilitation</th>
-                <th scope="col">Date d'inscription</th>
-                <th scope="col">Date de dernière visite</th>
-                <!--<th scope="col">Date de dernier créneau</th>-->
-              </tr>
-            </thead>
-            <tbody>
-                <?php
-                foreach($listOfUsers as $v):
-                ?>
-                <tr>
-                    <th scope="col"><?=$v['nom']?></th>
-                    <th scope="col"><?=$v['prenom']?></th>
-                    <th scope="col"><?=$v['pseudo']?></th>
-                    <th scope="col"><?=$v['admin']?></th>
-                    <th scope="col"><?=$v['date_inscription']?></th>
-                    <th scope="col"><?=$v['date_derniere_visite']?></th>
-<!--                    Rajouter éventuellement date dernier et prochain creneau-->
-                </tr>
-                <?php              
-                endforeach;
-                ?>
-            </tbody>
-            <tfoot>
-              <tr>
-                <th scope="col"></th>
-                <th scope="col"></th>
-                <th scope="col"></th>
-                <th scope="col"></th>
-                <th scope="col"></th>
-                <th scope="col"></th>
-                
-              </tr>
-            </tfoot>
-          </table>
-      </form>
+<div class="container bg-light rounded mt-4 mb-4 p-3">
+    <form method="get" class="mb-3">
+        <div class="row g-2 align-items-end">
+            <div class="col-md-6">
+                <label for="search" class="form-label">Rechercher un bénévole (nom ou prénom)</label>
+                <input
+                    type="text"
+                    id="search"
+                    name="search"
+                    class="form-control"
+                    value="<?= htmlspecialchars($searchTerm, ENT_QUOTES, 'UTF-8') ?>"
+                    placeholder="Exemple : Dupont ou Marie"
+                >
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-primary">Rechercher</button>
+            </div>
+            <div class="col-auto">
+                <a href="list.php" class="btn btn-outline-secondary">Réinitialiser</a>
+            </div>
+        </div>
+    </form>
+
+    <?php if ($successMessage !== null): ?>
+        <div class="alert alert-success" role="alert">
+            <?= htmlspecialchars($successMessage, ENT_QUOTES, 'UTF-8') ?>
+        </div>
+    <?php endif; ?>
+
+    <table class="table table-striped">
+        <thead>
+          <tr>
+            <th scope="col">Nom</th>
+            <th scope="col">Prénom</th>
+            <th scope="col">Pseudo</th>
+            <th scope="col">Habilitation</th>
+            <th scope="col">Date d'inscription</th>
+            <th scope="col">Date de dernière visite</th>
+            <!--<th scope="col">Date de dernier créneau</th>-->
+          </tr>
+        </thead>
+        <tbody>
+            <?php foreach($listOfUsers as $v): ?>
+            <tr>
+                <td><?= htmlspecialchars((string) $v['nom'], ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars((string) $v['prenom'], ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars((string) $v['pseudo'], ENT_QUOTES, 'UTF-8') ?></td>
+                <td>
+                    <form method="post" class="d-flex gap-2 align-items-center mb-0">
+                        <input type="hidden" name="uuid_user" value="<?= htmlspecialchars((string) $v['uuid_user'], ENT_QUOTES, 'UTF-8') ?>">
+                        <select name="habilitation" class="form-select form-select-sm" style="max-width: 95px;">
+                            <option value="1" <?= ((int) $v['admin'] === 1) ? 'selected' : '' ?>>1</option>
+                            <option value="2" <?= ((int) $v['admin'] === 2) ? 'selected' : '' ?>>2</option>
+                        </select>
+                        <button type="submit" class="btn btn-sm btn-outline-primary">Valider</button>
+                    </form>
+                </td>
+                <td><?= htmlspecialchars((string) $v['date_inscription'], ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars((string) $v['date_derniere_visite'], ENT_QUOTES, 'UTF-8') ?></td>
+<!--                Rajouter éventuellement date dernier et prochain creneau-->
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+        <tfoot>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col"></th>
+            <th scope="col"></th>
+            <th scope="col"></th>
+            <th scope="col"></th>
+            <th scope="col"></th>
+          </tr>
+        </tfoot>
+      </table>
   </div>
 
 <?php


### PR DESCRIPTION
### Motivation
- Permettre aux administrateurs de rechercher rapidement un bénévole par `nom` ou `prénom` et d'ajuster son niveau d'habilitation sans quitter la liste. 

### Description
- Ajout d'un champ de recherche GET `search` dans `public/list.php` avec filtrage insensible à la casse via `mb_strtolower` et `mb_strpos` pour filtrer la liste retournée par `getAllUsersAndDate`.
- Ajout d'un formulaire POST par ligne pour modifier l'habilitation et validation serveur des valeurs autorisées (`1` ou `2`) avant d'appeler `updateHabilitation`.
- Affichage d'un message de confirmation après mise à jour et réinitialisation possible de la recherche via un bouton.
- Sécurisation de l'affichage des données utilisateur et du champ de recherche avec `htmlspecialchars`.

### Testing
- Exécution de la vérification de syntaxe PHP avec `php -l public/list.php`, résultat : pas d'erreurs de syntaxe (succès).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d50c65c5688327803aa47d340a7f02)