### PR TITLE
Improve responsive layout for calendrier.php to fit viewport

### DIFF
--- a/public/calendrier.php
+++ b/public/calendrier.php
@@ -25,7 +25,7 @@ entete('Calendrier','Calendrier des créneaux','1');
 
 <div class="calendar">
 
-  <div class="d-flex flex-row align-items-center justify-content-between mx-sm-3">
+  <div class="calendar__topbar d-flex flex-row align-items-center justify-content-between mx-sm-3">
     <h1><?= $month->toString(); ?></h1>
 
     <?php if (isset($_GET['success'])): ?>
@@ -36,9 +36,17 @@ entete('Calendrier','Calendrier des créneaux','1');
       </div>
     <?php endif; ?>
 
-    <div>
-      <a href="calendrier.php?month=<?= $month->previousMonth()->month; ?>&year=<?= $month->previousMonth()->year; ?>" class="btn btn-primary">&lt;</a>
-      <a href="calendrier.php?month=<?= $month->nextMonth()->month; ?>&year=<?= $month->nextMonth()->year; ?>" class="btn btn-primary">&gt;</a>
+    <div class="calendar__nav">
+      <a href="calendrier.php?month=<?= $month->previousMonth()->month; ?>&year=<?= $month->previousMonth()->year; ?>" class="btn btn-primary calendar__nav-desktop-btn">&lt;</a>
+      <a href="calendrier.php?month=<?= $month->nextMonth()->month; ?>&year=<?= $month->nextMonth()->year; ?>" class="btn btn-primary calendar__nav-desktop-btn">&gt;</a>
+      <details class="calendar__nav-dropdown">
+        <summary class="btn btn-primary">Navigation</summary>
+        <div class="calendar__nav-menu">
+          <a href="calendrier.php?month=<?= $month->previousMonth()->month; ?>&year=<?= $month->previousMonth()->year; ?>" class="btn btn-outline-primary btn-sm">Mois précédent</a>
+          <a href="calendrier.php" class="btn btn-outline-primary btn-sm">Mois actuel</a>
+          <a href="calendrier.php?month=<?= $month->nextMonth()->month; ?>&year=<?= $month->nextMonth()->year; ?>" class="btn btn-outline-primary btn-sm">Mois suivant</a>
+        </div>
+      </details>
     </div>
   </div>
 

--- a/public/css/calendar.css
+++ b/public/css/calendar.css
@@ -6,6 +6,47 @@
   min-height: 0;
 }
 
+.calendar__topbar {
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.calendar__nav {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.calendar__nav-dropdown {
+  display: none;
+}
+
+.calendar__nav-dropdown summary {
+  list-style: none;
+  cursor: pointer;
+}
+
+.calendar__nav-dropdown summary::-webkit-details-marker {
+  display: none;
+}
+
+.calendar__nav-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 185px;
+  padding: 8px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
 .calendar__table {
   width: 100%;
   height: 100%;
@@ -112,6 +153,11 @@
     height: calc(100vh - 72px);
   }
 
+  .calendar__topbar h1 {
+    margin-bottom: 0;
+    font-size: 1.3rem;
+  }
+
   .calendar__table td {
     padding: 4px;
   }
@@ -121,5 +167,13 @@
     height: 11px;
     line-height: 11px;
     font-size: 0;
+  }
+
+  .calendar__nav-desktop-btn {
+    display: none;
+  }
+
+  .calendar__nav-dropdown {
+    display: block;
   }
 }

--- a/public/css/calendar.css
+++ b/public/css/calendar.css
@@ -1,18 +1,25 @@
 .calendar {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 96px);
+  min-height: 0;
 }
 
 .calendar__table {
   width: 100%;
-  height: calc(100vh - 128px);
+  height: 100%;
+  table-layout: fixed;
+  font-size: clamp(0.72rem, 0.9vw, 0.95rem);
 }
 
 .calendar__table td {
-  padding: 10px;
+  padding: clamp(4px, 0.7vw, 10px);
   border: 1px solid #CCC;
   vertical-align: top;
   width: 14.29%;
   height: 20%;
+  overflow: hidden;
 }
 
 .calendar__table td.is-today {
@@ -26,11 +33,11 @@
 .calendar__weekday {
   font-weight: bold;
   color: #000;
-  font-size: 1.2em;
+  font-size: clamp(0.75rem, 1vw, 1.1rem);
 }
 
 .calendar__day {
-  font-size: 1.3em;
+  font-size: clamp(0.8rem, 1.1vw, 1.15rem);
 }
 
 .calendar__othermonth .calendar__day {
@@ -83,4 +90,36 @@
   text-decoration: none;
   color: #FFF;
   transform: scale(1.2);
+}
+
+.calendar__event {
+  font-size: clamp(0.65rem, 0.8vw, 0.85rem);
+  line-height: 1.2;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 992px) {
+  .calendar {
+    height: calc(100vh - 84px);
+  }
+}
+
+@media (max-width: 768px) {
+  .calendar {
+    height: calc(100vh - 72px);
+  }
+
+  .calendar__table td {
+    padding: 4px;
+  }
+
+  .calendar__light {
+    width: 11px;
+    height: 11px;
+    line-height: 11px;
+    font-size: 0;
+  }
 }


### PR DESCRIPTION
### Motivation
- Rendre la page `calendrier.php` pleinement visible dans la fenêtre en réduisant la taille et l'empreinte verticale du calendrier sur petits écrans et tablettes.
- Éviter les débordements de contenu dans les cellules du calendrier pour améliorer la lisibilité et l'utilisation sur mobile.

### Description
- Ajustement du conteneur ` .calendar` pour un comportement en colonne flexible et occupation de la hauteur disponible via `height: calc(100vh - ...)` afin que le tableau utilise l'espace restant.
- Passage du tableau à `table-layout: fixed` et introduction de `font-size` responsive avec `clamp()` pour compresser la grille tout en conservant la lisibilité.
- Réduction des espacements et utilisation de `padding: clamp(...)`, `overflow: hidden` sur les cellules et `text-overflow: ellipsis` pour tronquer proprement les lignes d'événement via la règle `.calendar__event`.
- Ajout de media queries (`max-width: 992px` et `max-width: 768px`) pour diminuer la hauteur globale et la taille des indicateurs visuels sur écrans plus petits.

### Testing
- Exécution de la vérification de syntaxe PHP avec `php -l public/calendrier.php` qui a réussi.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d5e211c0832787d3a618a9bacadd)