### PR TITLE
Ajouter un menu hamburger rétractable pour la navigation mobile

### DIFF
--- a/includes/nav.php
+++ b/includes/nav.php
@@ -1,6 +1,10 @@
 
 <nav class="navforum">
-        <ul class="liste">
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="menu-principal">
+                <span class="menu-toggle__icon" aria-hidden="true"></span>
+                <span class="menu-toggle__label">Menu</span>
+        </button>
+        <ul class="liste" id="menu-principal">
                 <li <?php if($page == 1){echo 'class="puce vert"';}else{echo 'class="puce bleu"';} ?>><a class="lienpuce" href="calendrier.php">Voir le planning</a></li>
                 <li <?php if($page == 2){echo 'class="puce vert"';}else{echo 'class="puce bleu"';} ?>><a class="lienpuce" href="inscription.php">Prendre un créneau</a></li>
                 <li <?php if($page == 3){echo 'class="puce vert"';}else{echo 'class="puce bleu"';} ?>><a class="lienpuce" href="informations.php">Vos informations</a></li>
@@ -11,3 +15,21 @@
                 <li class="puce bleu"><a class="lienpuce" href="logout.php">Logout</a></li>     
         </ul>
 </nav>
+<script>
+        (function () {
+                var nav = document.querySelector('.navforum');
+                if (!nav) {
+                        return;
+                }
+                var button = nav.querySelector('.menu-toggle');
+                var menu = nav.querySelector('.liste');
+                if (!button || !menu) {
+                        return;
+                }
+
+                button.addEventListener('click', function () {
+                        var isOpen = nav.classList.toggle('navforum--open');
+                        button.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+                });
+        })();
+</script>

--- a/includes/nav.php
+++ b/includes/nav.php
@@ -31,5 +31,12 @@
                         var isOpen = nav.classList.toggle('navforum--open');
                         button.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
                 });
+
+                window.addEventListener('resize', function () {
+                        if (window.innerWidth > 900) {
+                                nav.classList.remove('navforum--open');
+                                button.setAttribute('aria-expanded', 'false');
+                        }
+                });
         })();
 </script>

--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -10,6 +10,51 @@
     background-color: #FBF3E4;
 }
 
+.menu-toggle{
+    display: none;
+    align-items: center;
+    gap: 8px;
+    border: none;
+    border-radius: 6px;
+    background-color: #23A3D9;
+    color: white;
+    font-weight: bold;
+    padding: 10px 14px;
+    margin: 10px;
+    box-shadow: 0px 0px 5px black;
+    cursor: pointer;
+}
+
+.menu-toggle__icon,
+.menu-toggle__icon::before,
+.menu-toggle__icon::after{
+    display: block;
+    width: 20px;
+    height: 2px;
+    background-color: white;
+    border-radius: 2px;
+    transition: transform .2s ease, opacity .2s ease;
+}
+
+.menu-toggle__icon{
+    position: relative;
+}
+
+.menu-toggle__icon::before,
+.menu-toggle__icon::after{
+    content: "";
+    position: absolute;
+    left: 0;
+}
+
+.menu-toggle__icon::before{
+    top: -6px;
+}
+
+.menu-toggle__icon::after{
+    top: 6px;
+}
+
 .navvente{
     margin-bottom: 10px;
     width: 100%;
@@ -117,3 +162,41 @@
     background-color: #23A3D9;
 }
 
+@media (max-width: 900px){
+    .navforum{
+        height: auto;
+        padding-bottom: 10px;
+    }
+
+    .menu-toggle{
+        display: inline-flex;
+    }
+
+    .navforum > .liste{
+        display: none;
+        flex-direction: column;
+        align-items: stretch;
+        margin: 0 10px;
+    }
+
+    .navforum--open > .liste{
+        display: flex;
+    }
+
+    .navforum > .liste > .puce{
+        width: 100%;
+        margin: 6px 0;
+    }
+
+    .navforum--open .menu-toggle__icon{
+        background-color: transparent;
+    }
+
+    .navforum--open .menu-toggle__icon::before{
+        transform: translateY(6px) rotate(45deg);
+    }
+
+    .navforum--open .menu-toggle__icon::after{
+        transform: translateY(-6px) rotate(-45deg);
+    }
+}

--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -173,14 +173,14 @@
     }
 
     .navforum > .liste{
-        display: none;
+        display: none !important;
         flex-direction: column;
         align-items: stretch;
         margin: 0 10px;
     }
 
-    .navforum--open > .liste{
-        display: flex;
+    .navforum.navforum--open > .liste{
+        display: flex !important;
     }
 
     .navforum > .liste > .puce{


### PR DESCRIPTION
### Motivation
- Réduire l'espace occupé par la barre de navigation sur les petits écrans en proposant un menu repliable (hamburger) pour améliorer l'ergonomie mobile.

### Description
- Ajout d'un bouton `menu-toggle` dans `includes/nav.php` avec les attributs d'accessibilité `aria-expanded` et `aria-controls` et conservation des liens existants dans la liste `#menu-principal`.
- Ajout d'un script inline léger dans `includes/nav.php` qui bascule la classe `navforum--open` et met à jour l'état ARIA lors du clic sur le bouton.
- Ajout des styles dans `public/css/nav.css` pour le bouton hamburger, l'icône (barres → croix) et une media query `@media (max-width: 900px)` qui masque la liste de liens par défaut et l'affiche quand `navforum--open` est actif.
- Le rendu desktop existant est préservé et le comportement mobile est isolé par la media query.

### Testing
- Exécution de la vérification de syntaxe PHP `php -l includes/nav.php` : OK (pas d'erreur de syntaxe).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d7aaa1dc832798c12527955ef5d2)