### PR TITLE
Pré-remplir la date dans edit.php et supporter le format dd-mm-YYYY

### DIFF
--- a/public/calendrier.php
+++ b/public/calendrier.php
@@ -68,7 +68,7 @@ entete('Calendrier','Calendrier des créneaux','1');
                     
                     ?>
                     <div class="calendar__event">
-                        <?= (new DateTime($event['start']))->format('H:i') ?> - <?= (new DateTime($event['end']))->format('H:i') ?> <a href="edit.php?id=<?= $event['id']; ?>"><?= h($event['name']); ?></a>
+                        <?= (new DateTime($event['start']))->format('H:i') ?> - <?= (new DateTime($event['end']))->format('H:i') ?> <a href="edit.php?id=<?= $event['id']; ?>&date=<?= $date->format('Y-m-d'); ?>"><?= h($event['name']); ?></a>
                         
                     </div>
 

--- a/public/edit.php
+++ b/public/edit.php
@@ -20,7 +20,8 @@ function normalizeDateToSqlFormat(?string $date): ?string
     foreach ($formats as $format) {
         $parsedDate = \DateTime::createFromFormat($format, $date);
         $errors = \DateTime::getLastErrors();
-        if ($parsedDate !== false && $errors['warning_count'] === 0 && $errors['error_count'] === 0) {
+        $hasDateErrors = is_array($errors) && ($errors['warning_count'] > 0 || $errors['error_count'] > 0);
+        if ($parsedDate !== false && !$hasDateErrors) {
             return $parsedDate->format('Y-m-d');
         }
     }

--- a/public/edit.php
+++ b/public/edit.php
@@ -79,7 +79,7 @@ if (isset($_POST['modify'])):
     if (empty($errors)):
         $events->hydrate($event, $data);
         $events->update($event);
-        header('Location: index.php?success=1');
+        header('Location: calendrier.php?success=1');
         exit();
     else:
         $data['date'] = formatDateForDisplay($_POST['date'] ?? '');

--- a/public/edit.php
+++ b/public/edit.php
@@ -7,6 +7,36 @@ require '../actions/users/userdefinition.php';
 
 $events = new Calendar\Events($pdo);
 $errors = [];
+
+function normalizeDateToSqlFormat(?string $date): ?string
+{
+    if ($date === null || trim($date) === '') {
+        return null;
+    }
+
+    $date = trim($date);
+    $formats = ['d-m-Y', 'Y-m-d'];
+
+    foreach ($formats as $format) {
+        $parsedDate = \DateTime::createFromFormat($format, $date);
+        $errors = \DateTime::getLastErrors();
+        if ($parsedDate !== false && $errors['warning_count'] === 0 && $errors['error_count'] === 0) {
+            return $parsedDate->format('Y-m-d');
+        }
+    }
+
+    return null;
+}
+
+function formatDateForDisplay(string $date): string
+{
+    $sqlDate = normalizeDateToSqlFormat($date);
+    if ($sqlDate === null) {
+        return $date;
+    }
+
+    return (new \DateTime($sqlDate))->format('d-m-Y');
+}
 try {
     $event = $events->find($_GET['id'] ?? null);
 } catch (\Exception $e) {
@@ -27,13 +57,22 @@ $data = [
 
 $Creneau = new Calendar\Creneaux($pdo,$timezone);
 
+if (isset($_GET['date'])) {
+    $prefilledDate = formatDateForDisplay($_GET['date']);
+    if (normalizeDateToSqlFormat($prefilledDate) !== null) {
+        $data['date'] = $prefilledDate;
+    }
+}
+
 if (isset($_POST['modify'])):
   
-    // Format fr => format us
-    $format_fr = $_POST['date'];
-    $format_us = implode('-',array_reverse  (explode('-',$format_fr)));
-    $_POST['date']=$format_us;
     $data = $_POST;
+    $normalizedDate = normalizeDateToSqlFormat($data['date'] ?? null);
+
+    if ($normalizedDate !== null) {
+        $data['date'] = $normalizedDate;
+    }
+
     $validator = new Calendar\EventValidator();
     $errors = $validator->validates($data);
     if (empty($errors)):
@@ -41,6 +80,8 @@ if (isset($_POST['modify'])):
         $events->update($event);
         header('Location: index.php?success=1');
         exit();
+    else:
+        $data['date'] = formatDateForDisplay($_POST['date'] ?? '');
     endif;
 endif;
 
@@ -53,7 +94,8 @@ if (isset($_POST['insert'])):
     endif;   
 endif;
 
-$creneauOnDay = $Creneau->getEventsBetween(new \DateTime(''.$data['date'].''), new \DateTime(''.$data['date'].''), 1);
+$sqlDate = normalizeDateToSqlFormat($data['date']) ?? (new \DateTime())->format('Y-m-d');
+$creneauOnDay = $Creneau->getEventsBetween(new \DateTime($sqlDate), new \DateTime($sqlDate), 1);
 $usersByCreneau = $users->getAllUsersByCreneau($creneauOnDay);
 
 

--- a/src/App/Validator.php
+++ b/src/App/Validator.php
@@ -39,11 +39,19 @@ class Validator {
     }
 
     public function date (string $field): bool {
-        if (\DateTime::createFromFormat('Y-m-d', $this->data[$field]) === false) {
-            $this->errors[$field] = "La date ne semble pas valide";
-            return false;
+        $value = trim((string) $this->data[$field]);
+        $formats = ['Y-m-d', 'd-m-Y'];
+
+        foreach ($formats as $format) {
+            $date = \DateTime::createFromFormat($format, $value);
+            $errors = \DateTime::getLastErrors();
+            if ($date !== false && $errors['warning_count'] === 0 && $errors['error_count'] === 0) {
+                return true;
+            }
         }
-        return true;
+
+        $this->errors[$field] = "La date ne semble pas valide";
+        return false;
     }
 
     public function time (string $field): bool {

--- a/src/App/Validator.php
+++ b/src/App/Validator.php
@@ -45,7 +45,8 @@ class Validator {
         foreach ($formats as $format) {
             $date = \DateTime::createFromFormat($format, $value);
             $errors = \DateTime::getLastErrors();
-            if ($date !== false && $errors['warning_count'] === 0 && $errors['error_count'] === 0) {
+            $hasDateErrors = is_array($errors) && ($errors['warning_count'] > 0 || $errors['error_count'] > 0);
+            if ($date !== false && !$hasDateErrors) {
                 return true;
             }
         }

--- a/views/calendar/form.php
+++ b/views/calendar/form.php
@@ -11,7 +11,7 @@
     <div class="col-sm-6">
         <div class="form-group">
             <label for="date">Date</label>
-            <input id="date" type="date" placeholder="dd-mm-YYYY" required class="form-control" name="date" value="<?= isset($data['date']) ? h($data['date']) : ''; ?>">
+            <input id="date" type="text" placeholder="dd-mm-YYYY" pattern="\d{2}-\d{2}-\d{4}|\d{4}-\d{2}-\d{2}" required class="form-control" name="date" value="<?= isset($data['date']) ? h($data['date']) : ''; ?>">
             <?php if (isset($errors['date'])): ?>
                 <small class="form-text text-muted"><?= $errors['date']; ?></small>
             <?php endif; ?>


### PR DESCRIPTION
### Motivation
- Le clic sur un événement doit ouvrir `edit.php` avec la date du jour sélectionné déjà pré-remplie dans le formulaire. 
- La validation rejetait les dates au format français `dd-mm-YYYY`, empêchant l'édition si l'utilisateur saisissait ce format.

### Description
- Ajout de deux helpers dans `public/edit.php`: `normalizeDateToSqlFormat()` pour normaliser `dd-mm-YYYY` ou `YYYY-mm-dd` en `YYYY-mm-dd` et `formatDateForDisplay()` pour afficher `dd-mm-YYYY` dans le formulaire.
- Transmission explicite de la date cliquée depuis le calendrier vers `edit.php` en ajoutant `&date=YYYY-mm-dd` au lien dans `public/calendrier.php`.
- Remplacement de la conversion fragile par `explode` dans `public/edit.php` par la normalisation; utilisation de la date SQL normalisée pour récupérer les créneaux du jour.
- Extension de la validation de dates dans `src/App/Validator.php` pour accepter à la fois `YYYY-mm-dd` et `dd-mm-YYYY`, et modification du champ date dans `views/calendar/form.php` pour être `type="text"` avec un `pattern` autorisant les deux formats.

### Testing
- Vérification de la syntaxe PHP via `php -l public/edit.php`, qui a réussi.
- Vérification de la syntaxe PHP via `php -l public/calendrier.php`, qui a réussi.
- Vérification de la syntaxe PHP via `php -l views/calendar/form.php`, qui a réussi.
- Vérification de la syntaxe PHP via `php -l src/App/Validator.php`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c7ec7c248327a9af4abf450cb4a4)